### PR TITLE
support setting environmentvariables

### DIFF
--- a/templates/job.erb
+++ b/templates/job.erb
@@ -8,9 +8,13 @@
 # environment => "foo=bar\nbaz=bam"
 # environment => [ "foo=bar", "baz="bam" ]
 
-<% Array(environment).join("\n").split(%r{\n}).each do |f| %>
-one line: <%= f %>
-<% end %>
+<% if defined?(environment)
+     Array(environment).join("\n").split(%r{\n}).each do |f|
+       if f.match(%r{\S}) -%>
+<%= f %>
+<%     end
+     end
+   end -%>
 
 <%= minute %> <%= hour %> <%= date %> <%= month %> <%= weekday %>  <%= user %> <%= command %>
 


### PR DESCRIPTION
I added some code to job.erb to handle setting environment variables.  Now you can do 

```
environment => [ " foo=bar", "baz="bam"]
```

or 

```
environment => "foo=bar\nbaz=bam"
```

and get 

```
foo=bar
baz=bam
var2=val2

* * * * *  username command
```

What do you think of that?
