### PR TITLE
Redhat / CentOS package name is cronie

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,3 +1,8 @@
 class cron::install {
-  package { 'cron': ensure => present }
+  $package_name = $operatingsystem ? {
+    /(RedHat|CentOS)/ => 'cronie',
+    default           => 'cron',
+  }
+
+  package { $package_name: ensure => present }
 }


### PR DESCRIPTION
Thanks for the simple yet elegant cron module. This pull request is a quick modification to get it working smoother on CentOS / RHEL systems (the cron package name is cronie). Everything else seems to work fine in my development branch nodes so far.
