### PR TITLE
be helpful if we don't see name=value

### DIFF
--- a/templates/job.erb
+++ b/templates/job.erb
@@ -5,10 +5,13 @@
 
 # Environment Settings
 <% Array(environment).join("\n").split(%r{\n}).each do |env_var|
-     if env_var.match(%r{\S}) -%>
-<%= env_var %>
-<%   end
-   end -%>
+      if env_var.match(%r{^\S+=\S+}) %>
+<%= env_var -%>
+<%    elsif env_var.match(%r{\S}) %>
+# possible error from puppet, doesn't look like "name=value": <%= env_var -%>
+<%   #else is only whitespace, so no output
+    end
+   end %>
 
 # Job Definition
 <%= minute %> <%= hour %> <%= date %> <%= month %> <%= weekday %>  <%= user %>  <%= command %>


### PR DESCRIPTION
I noticed an improvement we could still make.  I had been constructing my environment variables programmatically, and I had a situation where the values where coming out blank, so my cron files had something like

SOMETHING=

which makes cron throw and error and refuse to load the file, at least on debian squeeze. 

I added some logic to try to be helpful to the user.  What do you think?
