### PR TITLE
update template to avoid puppet 3.2 deprecated warnings

### DIFF
--- a/templates/job.erb
+++ b/templates/job.erb
@@ -1,10 +1,10 @@
 ###########################################################################################
 ### This file is managed by puppet, and is refreshed regularly. Edit at your own peril! ###
 ###########################################################################################
-## <%= name %> Cron Job
+## <%= @name %> Cron Job
 
 # Environment Settings
-<% Array(environment).join("\n").split(%r{\n}).each do |env_var|
+<% Array(@environment).join("\n").split(%r{\n}).each do |env_var|
      if env_var.match(%r{\S+=\S+}) -%>
 <%= env_var %>
 <%   elsif env_var.match(%r{\S}) -%>
@@ -13,5 +13,5 @@
    end -%>
 
 # Job Definition
-<%= minute %> <%= hour %> <%= date %> <%= month %> <%= weekday %>  <%= user %>  <%= command %>
+<%= @minute %> <%= @hour %> <%= @date %> <%= @month %> <%= @weekday %>  <%= @user %>  <%= @command %>
 


### PR DESCRIPTION
Removes warnings like:

``` Warning: Variable access via 'name' is deprecated. Use '@name' instead.
template[.../modules/cron/templates/job.erb]:4

```
```
