### PR TITLE
Change all files to be owned by root rather than cron owner

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -40,7 +40,7 @@ define cron::job(
   file {
     "job_${title}":
       ensure  => file,
-      owner   => $user,
+      owner   => 'root',
       group   => 'root',
       mode    => $mode,
       path    => "/etc/cron.d/${title}",

--- a/spec/defines/job_spec.rb
+++ b/spec/defines/job_spec.rb
@@ -38,7 +38,7 @@ describe 'cron::job' do
 
     it do
       should contain_file( "job_#{title}" ).with(
-        'owner'   => params[:user],
+        'owner'   => 'root',
         'mode'    => params[:mode]
       ).with_content(
         /\n#{params[:environment].join('\n')}\n/


### PR DESCRIPTION
- If files are owned by a different user than root then cron
  displays error
    crond[2221]: (root) WRONG FILE OWNER
