### PR TITLE
Added better ensure => absent handling

### DIFF
--- a/manifests/daily.pp
+++ b/manifests/daily.pp
@@ -1,7 +1,7 @@
 # Type: cron::daily
-# 
+#
 # This type creates a daily cron job via a file in /etc/cron.d
-# 
+#
 # Parameters:
 #   ensure - The state to ensure this resource exists in. Can be absent, present
 #     Defaults to 'present'
@@ -32,7 +32,7 @@
 
 define cron::daily(
   $minute = 0, $hour = 0, $environment = [], $user = 'root',
-  $mode = 0644, $ensure = 'present', $command
+  $mode = 0644, $ensure = 'present', $command = ''
 ){
   cron::job {
     $title:

--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -1,7 +1,7 @@
 # Type: cron::hourly
-# 
+#
 # This type creates an hourly cron job via a file in /etc/cron.d
-# 
+#
 # Parameters:
 #   ensure - The state to ensure this resource exists in. Can be absent, present
 #     Defaults to 'present'
@@ -27,7 +27,7 @@
 #   }
 define cron::hourly(
   $minute = 0, $environment = [], $user = 'root',
-  $mode = 0644, $ensure = 'present', $command
+  $mode = 0644, $ensure = 'present', $command = ''
 ) {
   cron::job {
     $title:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,4 +15,3 @@
 class cron {
   include cron::install
 }
-

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -1,7 +1,7 @@
 # Type: cron::job
-# 
+#
 # This type creates a cron job via a file in /etc/cron.d
-# 
+#
 # Parameters:
 #   ensure - The state to ensure this resource exists in. Can be absent, present
 #     Defaults to 'present'
@@ -36,23 +36,32 @@
 #   }
 define cron::job(
   $minute = '*', $hour = '*', $date = '*', $month = '*', $weekday = '*',
-  $environment = [], $user = 'root', $mode = 0644, $ensure = 'present', $command
+  $environment = [], $user = 'root', $mode = 0644, $ensure = 'present', $command = ''
 ) {
 
   case $ensure {
-    "present": { $real_ensure = file }
-    "absent":  { $real_ensure = absent }
-    default:   { fail("Invalid value '${ensure}' used for ensure") }
-  }
-
-  file {
-    "job_${title}":
-      ensure  => $real_ensure,
-      owner   => 'root',
-      group   => 'root',
-      mode    => $mode,
-      path    => "/etc/cron.d/${title}",
-      content => template( 'cron/job.erb' );
+    "present": {
+      if $command == '' {
+        fail("When 'ensure' is set to 'present', 'command' must be set")
+      }
+      file {
+        "job_${title}":
+          ensure  => file,
+          owner   => 'root',
+          group   => 'root',
+          mode    => $mode,
+          path    => "/etc/cron.d/${title}",
+          content => template( 'cron/job.erb' )
+      }
+    }
+    "absent": {
+      file {
+        "job_${title}":
+          ensure  => absent,
+          path    => "/etc/cron.d/${title}"
+      }
+    }
+    default: { fail("Invalid value '${ensure}' used for ensure") }
   }
 }
 

--- a/manifests/monthly.pp
+++ b/manifests/monthly.pp
@@ -1,7 +1,7 @@
 # Type: cron::monthly
-# 
+#
 # This type creates a monthly cron job via a file in /etc/cron.d
-# 
+#
 # Parameters:
 #   ensure - The state to ensure this resource exists in. Can be absent, present
 #     Defaults to 'present'
@@ -35,7 +35,7 @@
 
 define cron::monthly(
   $minute = 0, $hour = 0, $date = 1, $environment = [],
-  $user = 'root', $mode = 0644, $ensure = 'present', $command
+  $user = 'root', $mode = 0644, $ensure = 'present', $command = ''
 ) {
   cron::job {
     $title:

--- a/manifests/weekly.pp
+++ b/manifests/weekly.pp
@@ -1,7 +1,7 @@
 # Type: cron::weekly
-# 
+#
 # This type creates a cron job via a file in /etc/cron.d
-# 
+#
 # Parameters:
 #   ensure - The state to ensure this resource exists in. Can be absent, present
 #     Defaults to 'present'
@@ -35,7 +35,7 @@
 
 define cron::weekly(
   $minute = 0, $hour = 0, $weekday = 0, $environment = [],
-  $user = 'root', $mode = 0640, $ensure = 'present', $command
+  $user = 'root', $mode = 0640, $ensure = 'present', $command = ''
 ) {
   cron::job {
     $title:


### PR DESCRIPTION
This PR will allow users to use absent without needing to include a command

    cron::weekly{ 'mysqlbackup_weekly': ensure => absent }