### PR TITLE
Handles different cron package name in CentOS and RHEL 5. 

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -16,11 +16,16 @@
 class cron::install (
   $package_ensure = 'installed'
 ) {
-  $package_name = $::operatingsystem ? {
-    /(RedHat|CentOS|Amazon|OracleLinux)/ => 'cronie',
-    'Gentoo'                             => 'sys-process/vixie-cron',
-    'Ubuntu'                             => 'cron',
-    default                              => 'cron',
+  case $operatingsystem {
+    /(RedHat|CentOS|Amazon|OracleLinux)/:
+      {
+        case $operatingsystemmajrelease {
+          '5':     { $package_name = 'vixie-cron' }
+          default: { $package_name = 'cronie' }
+        }
+      }
+   'Gentoo':     { $package_name = 'sys-process/vixie-cron' }
+   default:      { $package_name = 'cron' }
   }
 
   package {
@@ -29,4 +34,3 @@ class cron::install (
       name   => $package_name;
   }
 }
-


### PR DESCRIPTION
Hi, we found that the CentOS/RHEL cron package name differs on 5 to 6 & 7. I couldn't make nested selectors work so I had to change this to a case statement. 
