### PR TITLE
fixes for future parser - mode must now be a string

### DIFF
--- a/manifests/daily.pp
+++ b/manifests/daily.pp
@@ -32,7 +32,7 @@
 
 define cron::daily(
   $command, $minute = 0, $hour = 0, $environment = [],
-  $user = 'root', $mode = 0644, $ensure = 'present'
+  $user = 'root', $mode = '0644', $ensure = 'present'
 ){
   cron::job {
     $title:

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -36,7 +36,7 @@
 #   }
 define cron::job(
   $command, $minute = '*', $hour = '*', $date = '*', $month = '*', $weekday = '*',
-  $environment = [], $user = 'root', $mode = 0644, $ensure = 'present'
+  $environment = [], $user = 'root', $mode = '0644', $ensure = 'present'
 ) {
 
   case $ensure {

--- a/manifests/monthly.pp
+++ b/manifests/monthly.pp
@@ -35,7 +35,7 @@
 
 define cron::monthly(
   $command, $minute = 0, $hour = 0, $date = 1,
-  $environment = [], $user = 'root', $mode = 0644, $ensure = 'present'
+  $environment = [], $user = 'root', $mode = '0644', $ensure = 'present'
 ) {
   cron::job {
     $title:


### PR DESCRIPTION
without this, a deprecation warning is output

Warning: Non-string values for the file mode property are deprecated. It must be a string, either a symbolic mode like 'o+w,a+r' or an octal representation like '0644' or '755'.
   (at /usr/local/rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/puppet-3.7.3/lib/puppet/type/file/mode.rb:69:in `block (2 levels) in <module:Puppet>')