### PR TITLE
add support for PSBM and CloudLinux

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -17,10 +17,10 @@ class cron::install (
   $package_ensure = 'installed'
 ) {
   $package_name = $::operatingsystem ? {
-    /(RedHat|CentOS|Amazon|OracleLinux)/ => 'cronie',
-    'Gentoo'                             => 'sys-process/vixie-cron',
-    'Ubuntu'                             => 'cron',
-    default                              => 'cron',
+    /(RedHat|CentOS|Amazon|OracleLinux|PSBM|CloudLinux)/  => 'cronie',
+    'Gentoo'                                              => 'sys-process/vixie-cron',
+    'Ubuntu'                                              => 'cron',
+    default                                               => 'cron',
   }
 
   package {


### PR DESCRIPTION
PSBM is Parallels Server for Bare Metal, PSBM and CloudLinux are both using cronie instead of cron
