### PR TITLE
store file mode as a string

### DIFF
--- a/manifests/daily.pp
+++ b/manifests/daily.pp
@@ -32,7 +32,7 @@
 
 define cron::daily(
   $command, $minute = 0, $hour = 0, $environment = [],
-  $user = 'root', $mode = 0644, $ensure = 'present'
+  $user = 'root', $mode = '0644', $ensure = 'present'
 ){
   cron::job {
     $title:

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -36,7 +36,7 @@
 #   }
 define cron::job(
   $command, $minute = '*', $hour = '*', $date = '*', $month = '*', $weekday = '*',
-  $environment = [], $user = 'root', $mode = 0644, $ensure = 'present'
+  $environment = [], $user = 'root', $mode = '0644', $ensure = 'present'
 ) {
 
   case $ensure {

--- a/manifests/monthly.pp
+++ b/manifests/monthly.pp
@@ -35,7 +35,7 @@
 
 define cron::monthly(
   $command, $minute = 0, $hour = 0, $date = 1,
-  $environment = [], $user = 'root', $mode = 0644, $ensure = 'present'
+  $environment = [], $user = 'root', $mode = '0644', $ensure = 'present'
 ) {
   cron::job {
     $title:


### PR DESCRIPTION
This allows for puppet4 support.

"The mode attribute of a file resource must be a string. If you use an
actual octal number, it will be converted to a decimal number, then
converted back to a string representing the wrong number when it comes
time to run the chown command."

https://docs.puppetlabs.com/puppet/latest/reference/experiments_future.html#check-the-mode-attribute-of-any-file-resources

----

Error on puppet4 without this change:

$ /opt/puppetlabs/bin/puppet agent -t --environment puppet4 --noop
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for puppetca1.testbed.ccs.ornl.gov
Error: Failed to apply catalog: Parameter mode failed on File[job_coreit]: The file mode specification must be a string, not 'Fixnum' at /etc/puppetlabs/code/environments/puppet4/upstream/cron/manifests/job.pp:48
