### PR TITLE
file mode specification must be a string, not Fixnum

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -36,7 +36,7 @@
 #   }
 define cron::job(
   $command, $minute = '*', $hour = '*', $date = '*', $month = '*', $weekday = '*',
-  $environment = [], $user = 'root', $mode = 0644, $ensure = 'present'
+  $environment = [], $user = 'root', $mode = '0644', $ensure = 'present'
 ) {
 
   case $ensure {


### PR DESCRIPTION
this fixes the error "The file mode specification must be a string, not 'Fixnum'" which you get if you do not specify the mode when you use the cron::job class on puppet 4.3.1