### PR TITLE
Add an optional comment to the job definitions

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -42,6 +42,7 @@ It allows specifying the following parameters:
   * user
   * command
   * environment
+  * comment
 
 Example:
   This would run the command "mysqldump -u root mydb" as root at 2:40 AM every day:
@@ -55,7 +56,8 @@ Example:
         weekday     => '*',
         user        => 'root',
         command     => 'mysqldump -u root mydb',
-        environment => [ 'MAILTO=root', 'PATH="/usr/bin:/bin"' ];
+        environment => [ 'MAILTO=root', 'PATH="/usr/bin:/bin"' ],
+        comment     => 'This job updates so and so then copies this to that',
     }
 
 ### cron::hourly
@@ -68,6 +70,7 @@ It allows specifying the following parameters:
   * user
   * command
   * environment
+  * comment
 
 Example:
   This would run the command "mysqldump -u root mydb" as root on the 20th minute of every hour:
@@ -78,6 +81,7 @@ Example:
         user        => 'root',
         command     => 'mysqldump -u root mydb',
         environment => "MAILTO=root\nPATH='/usr/bin:/bin'";
+        comment     => 'This job updates so and so then copies this to that',
     }
 
 ### cron::daily
@@ -91,6 +95,7 @@ It allows specifying the following parameters:
   * user
   * command
   * environment
+  * comment
 
 Example:
   This would run the command "mysqldump -u root mydb" as root at 2:40 AM every day, like the above generic example:
@@ -101,6 +106,7 @@ Example:
         hour    => '2',
         user    => 'root',
         command => 'mysqldump -u root mydb';
+        comment => 'This job updates so and so then copies this to that',
     }
 
 ### cron::weekly
@@ -115,6 +121,7 @@ It allows specifying the following parameters:
   * user
   * command
   * environment
+  * comment
 
 Example:
   This would run the command "mysqldump -u root mydb" as root at 4:40 AM every Sunday, like the above generic example:
@@ -126,6 +133,7 @@ Example:
         weekday => '0',
         user    => 'root',
         command => 'mysqldump -u root mydb';
+        comment => 'This job updates so and so then copies this to that',
     }
 
 ### cron::monthly
@@ -140,6 +148,7 @@ It allows specifying the following parameters:
   * user
   * command
   * environment
+  * comment
 
 Example:
   This would run the command "mysqldump -u root mydb" as root at 3:40 AM the 1st of every month, like the above generic example:
@@ -151,6 +160,7 @@ Example:
         date    => '1',
         user    => 'root',
         command => 'mysqldump -u root mydb';
+        comment => 'This job updates so and so then copies this to that',
     }
 
 ## Contributors:

--- a/manifests/daily.pp
+++ b/manifests/daily.pp
@@ -17,6 +17,8 @@
 #     Defaults to 0644.
 #   command - The command to execute.
 #     Defaults to undef.
+#   comment - Optional comment to add to the crontab file
+#     Defaults to undef
 #
 # Actions:
 #
@@ -33,7 +35,7 @@
 
 define cron::daily(
   $command = undef, $minute = 0, $hour = 0, $environment = [],
-  $user = 'root', $mode = '0644', $ensure = 'present'
+  $user = 'root', $mode = '0644', $ensure = 'present', $comment = undef,
 ){
   cron::job {
     $title:
@@ -46,7 +48,8 @@ define cron::daily(
       user        => $user,
       environment => $environment,
       mode        => $mode,
-      command     => $command;
+      command     => $command,
+      comment     => $comment,
   }
 }
 

--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -15,6 +15,8 @@
 #     Defaults to 'root'.
 #   command - The command to execute.
 #     Defaults to undef.
+#   comment - Optional comment to add to the crontab file
+#     Defaults to undef
 #
 # Actions:
 #
@@ -28,7 +30,7 @@
 #       command     => 'puppet doc --modulepath /etc/puppet/modules >/var/www/puppet_docs.mkd';
 #   }
 define cron::hourly(
-  $command = undef, $minute = 0, $environment = [],
+  $command = undef, $minute = 0, $environment = [], $comment = undef,
   $user = 'root', $mode = '0644', $ensure = 'present'
 ) {
   cron::job {
@@ -42,7 +44,8 @@ define cron::hourly(
       user        => $user,
       environment => $environment,
       mode        => $mode,
-      command     => $command;
+      command     => $command,
+      comment     => $comment,
   }
 }
 

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -23,6 +23,8 @@
 #     Defaults to 'root'.
 #   command - The command to execute.
 #     Defaults to undef.
+#   comment - Optional comment to add to the crontab file
+#     Defaults to undef
 #
 # Actions:
 #
@@ -37,7 +39,7 @@
 #   }
 define cron::job(
   $command = undef, $minute = '*', $hour = '*', $date = '*', $month = '*', $weekday = '*',
-  $environment = [], $user = 'root', $mode = '0644', $ensure = 'present'
+  $environment = [], $user = 'root', $mode = '0644', $ensure = 'present', $comment = undef,
 ) {
 
   case $ensure {

--- a/manifests/monthly.pp
+++ b/manifests/monthly.pp
@@ -19,6 +19,8 @@
 #     Defaults to 0644.
 #   command - The command to execute.
 #     Defaults to undef.
+#   comment - Optional comment to add to the crontab file
+#     Defaults to undef
 #
 # Actions:
 #
@@ -35,7 +37,7 @@
 #   }
 
 define cron::monthly(
-  $command = undef, $minute = 0, $hour = 0, $date = 1,
+  $command = undef, $minute = 0, $hour = 0, $date = 1, $comment = undef,
   $environment = [], $user = 'root', $mode = '0644', $ensure = 'present'
 ) {
   cron::job {
@@ -49,7 +51,8 @@ define cron::monthly(
       user        => $user,
       environment => $environment,
       mode        => $mode,
-      command     => $command;
+      command     => $command,
+      comment     => $comment,
   }
 }
 

--- a/manifests/weekly.pp
+++ b/manifests/weekly.pp
@@ -19,6 +19,8 @@
 #     Defaults to '0640'.
 #   command - The command to execute.
 #     Defaults to undef.
+#   comment - Optional comment to add to the crontab file
+#     Defaults to undef
 #
 # Actions:
 #
@@ -36,7 +38,7 @@
 
 define cron::weekly(
   $command = undef, $minute = 0, $hour = 0, $weekday = 0, $user = 'root',
-  $mode = '0640', $ensure = 'present', $environment = []
+  $mode = '0640', $ensure = 'present', $environment = [], $comment = undef,
 ) {
   cron::job {
     $title:
@@ -49,7 +51,8 @@ define cron::weekly(
       user        => $user,
       environment => $environment,
       mode        => $mode,
-      command     => $command;
+      command     => $command,
+      comment     => $comment,
   }
 }
 

--- a/spec/defines/daily_spec.rb
+++ b/spec/defines/daily_spec.rb
@@ -5,7 +5,8 @@ describe 'cron::daily' do
   let( :params ) {{
     :minute  => '59',
     :hour    => '1',
-    :command => 'mysqldump -u root test_db >some_file'
+    :command => 'mysqldump -u root test_db >some_file',
+    :comment => 'do this'
   }}
 
   it do
@@ -18,7 +19,8 @@ describe 'cron::daily' do
       'user'        => params[:user] || 'root',
       'environment' => params[:environment] || [],
       'mode'        => params[:mode] || '0644',
-      'command'     => params[:command]
+      'command'     => params[:command],
+      'comment'     => params[:comment]
     )
   end
 end

--- a/spec/defines/hourly_spec.rb
+++ b/spec/defines/hourly_spec.rb
@@ -4,7 +4,8 @@ describe 'cron::hourly' do
   let( :title )  { 'mysql_backup' }
   let( :params ) {{
     :minute  => '59',
-    :command => 'mysqldump -u root test_db >some_file'
+    :command => 'mysqldump -u root test_db >some_file',
+    :comment => 'do this'
   }}
 
   it do
@@ -17,7 +18,8 @@ describe 'cron::hourly' do
       'user'        => params[:user] || 'root',
       'environment' => params[:environment] || [],
       'mode'        => params[:mode] || '0644',
-      'command'     => params[:command]
+      'command'     => params[:command],
+      'comment'     => params[:comment]
     )
   end
 end

--- a/spec/defines/job_spec.rb
+++ b/spec/defines/job_spec.rb
@@ -33,6 +33,7 @@ describe 'cron::job' do
       :user        => 'admin',
       :mode        => '0640',
       :command     => 'mysqldump -u root test_db >some_file',
+      :comment     => 'do this'
     }}
     let( :cron_timestamp ) { get_timestamp( params ) }
 
@@ -48,6 +49,8 @@ describe 'cron::job' do
         /\s+#{params[:user]}\s+/
       ).with_content(
         /\s+#{params[:command]}\n/
+      ).with_content(
+        /\s+#{params[:comment]}\n/
       )
     end
   end

--- a/spec/defines/monthly_spec.rb
+++ b/spec/defines/monthly_spec.rb
@@ -6,7 +6,8 @@ describe 'cron::monthly' do
     :minute      => '59',
     :hour        => '1',
     :date        => '20',
-    :command     => 'mysqldump -u root test_db >some_file'
+    :command     => 'mysqldump -u root test_db >some_file',
+    :comment     => 'do this'
   }}
 
   it do
@@ -19,7 +20,8 @@ describe 'cron::monthly' do
       'user'        => params[:user] || 'root',
       'environment' => params[:environment] || [],
       'mode'        => params[:mode] || '0644',
-      'command'     => params[:command]
+      'command'     => params[:command],
+      'comment'     => params[:comment]
     )
   end
 end

--- a/spec/defines/weekly_spec.rb
+++ b/spec/defines/weekly_spec.rb
@@ -6,7 +6,8 @@ describe 'cron::weekly' do
     :minute  => '59',
     :hour    => '1',
     :weekday => '2',
-    :command => 'mysqldump -u root test_db >some_file'
+    :command => 'mysqldump -u root test_db >some_file',
+    :comment => 'do this'
   }}
 
   it do
@@ -19,7 +20,8 @@ describe 'cron::weekly' do
       'user'        => params[:user] || 'root',
       'environment' => params[:environment] || [],
       'mode'        => params[:mode] || '0640',
-      'command'     => params[:command]
+      'command'     => params[:command],
+      'comment'     => params[:comment]
     )
   end
 end

--- a/templates/job.erb
+++ b/templates/job.erb
@@ -2,6 +2,11 @@
 ### This file is managed by puppet, and is refreshed regularly. Edit at your own peril! ###
 ###########################################################################################
 ## <%= @name %> Cron Job
+<%- if @comment -%>
+##
+## <%= @comment %>
+##
+<%- end -%>
 
 # Environment Settings
 <% Array(@environment).join("\n").split(%r{\n}).each do |env_var|


### PR DESCRIPTION
Allows mentioning what the job does, to end up in the template
