### PR TITLE
fixed json gem install for ruby versions < 2.0

### DIFF
--- a/.travis/Gemfile
+++ b/.travis/Gemfile
@@ -11,3 +11,7 @@ if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
   gem 'rake',  '~> 10.5.0'
   gem 'rspec', '~> 2.0'
 end
+
+if RUBY_VERSION < '2.0'
+  gem 'json', '<= 1.8.3'
+end

--- a/.travis/Gemfile
+++ b/.travis/Gemfile
@@ -14,4 +14,5 @@ end
 
 if RUBY_VERSION < '2.0'
   gem 'json', '<= 1.8.3'
+  gem 'json_pure', '<= 1.8.3'
 end


### PR DESCRIPTION
due to a gem update, the newest versions of the json gem (>= 2.0) are only compatible with ruby versions >= 2.0
