### PR TITLE
Changing file permissions to be uniform across all frequencies

### DIFF
--- a/manifests/weekly.pp
+++ b/manifests/weekly.pp
@@ -16,7 +16,7 @@
 #   user - The user the cron job should be executed as.
 #     Defaults to 'root'.
 #   mode - The mode to set on the created job file
-#     Defaults to '0640'.
+#     Defaults to '0644'.
 #   command - The command to execute.
 #     Defaults to undef.
 #
@@ -36,7 +36,7 @@
 
 define cron::weekly(
   $command = undef, $minute = 0, $hour = 0, $weekday = 0, $user = 'root',
-  $mode = '0640', $ensure = 'present', $environment = []
+  $mode = '0644', $ensure = 'present', $environment = []
 ) {
   cron::job {
     $title:


### PR DESCRIPTION
Currently the permissions for daily, hourly, and monthly are all 0644, while weekly is 0640.  Recommending it is updated to 0644 to be uniform across the board unless there is a particular reason weekly should be different.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/torrancew/puppet-cron/48)
<!-- Reviewable:end -->
