### PR TITLE
Use operating system fact, don't depend on LSB

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -17,7 +17,7 @@ class cron::install (
   $package_ensure = 'installed'
 ) {
   $package_name = $::operatingsystem ? {
-    /(RedHat|CentOS|Amazon|OracleLinux)/ => $::lsbmajdistrelease ? {
+    /(RedHat|CentOS|Amazon|OracleLinux)/ => $::operatingsystemmajrelease ? {
       5       => 'vixie-cron',
       default => 'cronie',
     },


### PR DESCRIPTION
This could resolve #51.

The 'lsb*' facts need the tool `lsb_release`, which on my CentOS 6 system was not present and had some non-trivial dependencies.  The `operatingsystemmajrrelease` is equivalent per https://docs.puppet.com/facter/2.4/core_facts.html#operatingsystemmajrelease